### PR TITLE
Open window for earlier queued

### DIFF
--- a/consumer/src/main/java/dk/dbc/pgqueue/consumer/QueueWorker.java
+++ b/consumer/src/main/java/dk/dbc/pgqueue/consumer/QueueWorker.java
@@ -60,6 +60,7 @@ public interface QueueWorker {
 
     /**
      * Builder method for QueueWorker instance
+     *
      * @param <T> Job type
      */
     class Builder<T> {
@@ -68,6 +69,7 @@ public interface QueueWorker {
 
         private final QueueStorageAbstraction<T> storageAbstraction;
         private Integer maxTries;
+        private Long window;
         private Long emptyQueueSleep;
         private Long maxQueryTime;
         private Integer rescanEvery;
@@ -83,6 +85,7 @@ public interface QueueWorker {
         private Builder(QueueStorageAbstraction<T> storageAbstraction) {
             this.storageAbstraction = storageAbstraction;
             this.maxTries = null;
+            this.window = null;
             this.emptyQueueSleep = null;
             this.maxQueryTime = null;
             this.rescanEvery = null;
@@ -130,6 +133,17 @@ public interface QueueWorker {
          */
         public Builder<T> maxTries(int maxTries) {
             this.maxTries = setOrFail(this.maxTries, maxTries, "maxTries");
+            return this;
+        }
+
+        /**
+         * Set window in ms for uncommitted transactions
+         *
+         * @param window how many ms are looked back in time
+         * @return self
+         */
+        public Builder<T> window(long window) {
+            this.window = setOrFail(this.window, window, "window");
             return this;
         }
 
@@ -303,7 +317,8 @@ public interface QueueWorker {
                                            new Throttle(or(databaseConnectThrottle, "")),
                                            new Throttle(or(failureThrottle, "")),
                                            executor,
-                                           or(metricRegistry, new MetricRegistry()));
+                                           or(metricRegistry, new MetricRegistry()),
+                                           or(window, 100L));
             return new Harvester(config, dataSource, consumers);
         }
 

--- a/consumer/src/main/java/dk/dbc/pgqueue/consumer/Settings.java
+++ b/consumer/src/main/java/dk/dbc/pgqueue/consumer/Settings.java
@@ -38,6 +38,7 @@ class Settings<T> {
     final QueueStorageAbstraction<T> storageAbstraction;
     final DeduplicateAbstraction<T> deduplicateAbstraction;
     final int maxTries;
+    final long window;
     final long emptyQueueSleep;
     final long maxQueryTime;
     final int fullScanEvery;
@@ -47,8 +48,9 @@ class Settings<T> {
     final ExecutorService executor;
     final MetricRegistry metricRegistry;
 
-    Settings(List<String> consumerNames, QueueStorageAbstraction<T> storageAbstraction, DeduplicateAbstraction<T> deduplicateAbstraction, int maxTries, long emptyQueueSleep, long maxQueryTime, int fullScanEvery, int idleFullScanEvery, Throttle databaseConnectThrottle, Throttle failureThrottle, ExecutorService executor, MetricRegistry metricRegistry) {
+    Settings(List<String> consumerNames, QueueStorageAbstraction<T> storageAbstraction, DeduplicateAbstraction<T> deduplicateAbstraction, int maxTries, long emptyQueueSleep, long maxQueryTime, int fullScanEvery, int idleFullScanEvery, Throttle databaseConnectThrottle, Throttle failureThrottle, ExecutorService executor, MetricRegistry metricRegistry, long window) {
         this.maxTries = maxTries;
+        this.window = window;
         this.emptyQueueSleep = emptyQueueSleep;
         this.maxQueryTime = maxQueryTime;
         this.consumerNames = Collections.unmodifiableList(consumerNames);


### PR DESCRIPTION

Make a window lack in time when dequeuing, to avoid waiting for a rescan on semi long transactions